### PR TITLE
Extended with forward and reverse energy counters for L1, L2 and L3

### DIFF
--- a/dbus-sma-smartmeter.py
+++ b/dbus-sma-smartmeter.py
@@ -66,28 +66,37 @@ class DbusSMAEMService(object):
 
         self._obis_points = {
             # real values
-            0x00010400: {'name': 'pregard',        'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x00010800: {'name': 'pregardcounter', 'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/Energy/Forward'},
-            0x00020400: {'name': 'surplus',        'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x00020800: {'name': 'surpluscounter', 'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/Energy/Reverse'},
-            0x00200400: {'name': 'L1_voltage',     'length': 4, 'factor': 1/1000,    'unit': 'V',   'value': 0, 'path': '/Ac/L1/Voltage'},
-            0x00340400: {'name': 'L2_voltage',     'length': 4, 'factor': 1/1000,    'unit': 'V',   'value': 0, 'path': '/Ac/L2/Voltage'},
-            0x00480400: {'name': 'L3_voltage',     'length': 4, 'factor': 1/1000,    'unit': 'V',   'value': 0, 'path': '/Ac/L3/Voltage'},
-            0x00150400: {'name': 'L1_pregard',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x00290400: {'name': 'L2_pregard',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x003D0400: {'name': 'L3_pregard',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x00160400: {'name': 'L1_surplus',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x002a0400: {'name': 'L2_surplus',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x003E0400: {'name': 'L3_surplus',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
-            0x90000000: {'name': 'sw_version_raw', 'length': 4, 'factor': 1 ,        'unit': '',    'value': 0, 'path': ''},
+            0x00010400: {'name': 'pregard',             'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x00010800: {'name': 'pregardcounter',      'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/Energy/Forward'},
+            0x00020400: {'name': 'surplus',             'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x00020800: {'name': 'surpluscounter',      'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/Energy/Reverse'},
+            0x00200400: {'name': 'L1_voltage',          'length': 4, 'factor': 1/1000,    'unit': 'V',   'value': 0, 'path': '/Ac/L1/Voltage'},
+            0x00340400: {'name': 'L2_voltage',          'length': 4, 'factor': 1/1000,    'unit': 'V',   'value': 0, 'path': '/Ac/L2/Voltage'},
+            0x00480400: {'name': 'L3_voltage',          'length': 4, 'factor': 1/1000,    'unit': 'V',   'value': 0, 'path': '/Ac/L3/Voltage'},
+            0x001F0400: {'name': 'L1_current',          'length': 4, 'factor': 1/1000,    'unit': 'A',   'value': 0, 'path': ''},
+            0x00330400: {'name': 'L2_current',          'length': 4, 'factor': 1/1000,    'unit': 'A',   'value': 0, 'path': ''},
+            0x00470400: {'name': 'L3_current',          'length': 4, 'factor': 1/1000,    'unit': 'A',   'value': 0, 'path': ''},
+            0x00150400: {'name': 'L1_pregard',          'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x00290400: {'name': 'L2_pregard',          'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x003D0400: {'name': 'L3_pregard',          'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x00160400: {'name': 'L1_surplus',          'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x002a0400: {'name': 'L2_surplus',          'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x003E0400: {'name': 'L3_surplus',          'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+            0x00150800: {'name': 'L1_pregardcounter',   'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L1/Energy/Forward'},
+            0x00290800: {'name': 'L2_pregardcounter',   'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L2/Energy/Forward'},
+            0x003D0800: {'name': 'L3_pregardcounter',   'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L3/Energy/Forward'},
+            0x00160800: {'name': 'L1_surpluscounter',   'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L1/Energy/Reverse'},
+            0x002A0800: {'name': 'L2_surpluscounter',   'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L2/Energy/Reverse'},
+            0x003E0800: {'name': 'L3_surpluscounter',   'length': 8, 'factor': 1/3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L3/Energy/Reverse'},
+            0x90000000: {'name': 'sw_version_raw',      'length': 4, 'factor': 1,         'unit': '',    'value': 0, 'path': ''},
             # calculated values
-            0x00000001: {'name': 'power',          'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/Power'},
-            0x00000002: {'name': 'L1_power',       'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/L1/Power'},
-            0x00000003: {'name': 'L2_power',       'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/L2/Power'},
-            0x00000004: {'name': 'L2_power',       'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/L3/Power'},
-            0x00000005: {'name': 'L1_current',     'length': 0, 'factor': 1,         'unit': 'A',   'value': 0, 'path': '/Ac/L1/Current'},
-            0x00000006: {'name': 'L2_current',     'length': 0, 'factor': 1,         'unit': 'A',   'value': 0, 'path': '/Ac/L2/Current'},
-            0x00000007: {'name': 'L3_current',     'length': 0, 'factor': 1,         'unit': 'A',   'value': 0, 'path': '/Ac/L3/Current'},
+            0x00000001: {'name': 'power',               'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/Power'},
+            0x00000002: {'name': 'L1_power',            'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/L1/Power'},
+            0x00000003: {'name': 'L2_power',            'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/L2/Power'},
+            0x00000004: {'name': 'L2_power',            'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/L3/Power'},
+            0x00000005: {'name': 'L1_current',          'length': 0, 'factor': 1,         'unit': 'A',   'value': 0, 'path': '/Ac/L1/Current'},
+            0x00000006: {'name': 'L2_current',          'length': 0, 'factor': 1,         'unit': 'A',   'value': 0, 'path': '/Ac/L2/Current'},
+            0x00000007: {'name': 'L3_current',          'length': 0, 'factor': 1,         'unit': 'A',   'value': 0, 'path': '/Ac/L3/Current'},
         }
 
         self._dbusservice = VeDbusService(servicename)
@@ -206,9 +215,12 @@ class DbusSMAEMService(object):
                 self._obis_points[0x00000002]['value'] = round(self._obis_points[0x00150400]['value'] - self._obis_points[0x00160400]['value'], 2)
                 self._obis_points[0x00000003]['value'] = round(self._obis_points[0x00290400]['value'] - self._obis_points[0x002a0400]['value'], 2)
                 self._obis_points[0x00000004]['value'] = round(self._obis_points[0x003D0400]['value'] - self._obis_points[0x003E0400]['value'], 2)
-                self._obis_points[0x00000005]['value'] = round((self._obis_points[0x00150400]['value'] - self._obis_points[0x00160400]['value']) / self._obis_points[0x00200400]['value'], 2)
-                self._obis_points[0x00000006]['value'] = round((self._obis_points[0x00290400]['value'] - self._obis_points[0x002a0400]['value']) / self._obis_points[0x00340400]['value'], 2)
-                self._obis_points[0x00000007]['value'] = round((self._obis_points[0x003D0400]['value'] - self._obis_points[0x003E0400]['value']) / self._obis_points[0x00480400]['value'], 2)
+                #self._obis_points[0x00000005]['value'] = round((self._obis_points[0x00150400]['value'] - self._obis_points[0x00160400]['value']) / self._obis_points[0x00200400]['value'], 2)
+                #self._obis_points[0x00000006]['value'] = round((self._obis_points[0x00290400]['value'] - self._obis_points[0x002a0400]['value']) / self._obis_points[0x00340400]['value'], 2)
+                #self._obis_points[0x00000007]['value'] = round((self._obis_points[0x003D0400]['value'] - self._obis_points[0x003E0400]['value']) / self._obis_points[0x00480400]['value'], 2)
+                self._obis_points[0x00000005]['value'] = -self._obis_points[0x001F0400]['value'] if self._obis_points[0x00160400]['value'] > 0 else self._obis_points[0x001F0400]['value']
+                self._obis_points[0x00000006]['value'] = -self._obis_points[0x00330400]['value'] if self._obis_points[0x002a0400]['value'] > 0 else self._obis_points[0x00330400]['value']
+                self._obis_points[0x00000007]['value'] = -self._obis_points[0x00470400]['value'] if self._obis_points[0x003E0400]['value'] > 0 else self._obis_points[0x00470400]['value']
 
                 if self._hardware[SMASusyID]['active'] == False:
                     swr = self._obis_points[0x90000000]['value']

--- a/speedwire_test.py
+++ b/speedwire_test.py
@@ -25,7 +25,7 @@ obis_points = {
     #0x001F0400: {'name': 'L1_current',     'length': 4, 'factor': 1/1000,    'unit': 'A',   'value': 0, 'path': '/Ac/L1/Current'},
     #0x00330400: {'name': 'L2_current',     'length': 4, 'factor': 1/1000,    'unit': 'A',   'value': 0, 'path': '/Ac/L2/Current'},
     #0x00470400: {'name': 'L3_current',     'length': 4, 'factor': 1/1000,    'unit': 'A',   'value': 0, 'path': '/Ac/L3/Current'},
-    
+
     0x00150400: {'name': 'L1_pregard',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
     0x00290400: {'name': 'L2_pregard',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
     0x003D0400: {'name': 'L3_pregard',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
@@ -33,6 +33,14 @@ obis_points = {
     0x00160400: {'name': 'L1_surplus',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
     0x002a0400: {'name': 'L2_surplus',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
     0x003E0400: {'name': 'L3_surplus',     'length': 4, 'factor': 1/10,      'unit': 'W',   'value': 0, 'path': ''},
+
+    0x00150800: {'name': 'L1_pregardcounter', 'length': 8, 'factor': 1 / 3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L1/Energy/Forward'},
+    0x00290800: {'name': 'L2_pregardcounter', 'length': 8, 'factor': 1 / 3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L2/Energy/Forward'},
+    0x003D0800: {'name': 'L3_pregardcounter', 'length': 8, 'factor': 1 / 3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L3/Energy/Forward'},
+
+    0x00160800: {'name': 'L1_surpluscounter', 'length': 8, 'factor': 1 / 3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L1/Energy/Reverse'},
+    0x002A0800: {'name': 'L2_surpluscounter', 'length': 8, 'factor': 1 / 3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L2/Energy/Reverse'},
+    0x003E0800: {'name': 'L3_surpluscounter', 'length': 8, 'factor': 1 / 3600000, 'unit': 'kWh', 'value': 0, 'path': '/Ac/L3/Energy/Reverse'},
 
     # calculated values
     0x00000001: {'name': 'power',          'length': 0, 'factor': 1,         'unit': 'W',   'value': 0, 'path': '/Ac/Power'},
@@ -109,9 +117,9 @@ def decode_speedwire(data):
         obis_points[0x00000002]['value'] = round(obis_points[0x00150400]['value'] - obis_points[0x00160400]['value'], 2)
         obis_points[0x00000003]['value'] = round(obis_points[0x00290400]['value'] - obis_points[0x002a0400]['value'], 2)
         obis_points[0x00000004]['value'] = round(obis_points[0x003D0400]['value'] - obis_points[0x003E0400]['value'], 2)
-        obis_points[0x00000005]['value'] = round((obis_points[0x00150400]['value'] - obis_points[0x00160400]['value']) / obis_points[0x00200400]['value'], 2)
-        obis_points[0x00000006]['value'] = round((obis_points[0x00290400]['value'] - obis_points[0x002a0400]['value']) / obis_points[0x00340400]['value'], 2)
-        obis_points[0x00000007]['value'] = round((obis_points[0x003D0400]['value'] - obis_points[0x003E0400]['value']) / obis_points[0x00480400]['value'], 2)
+        obis_points[0x00000005]['value'] = -obis_points[0x001F0400]['value'] if obis_points[0x00160400]['value'] > 0 else obis_points[0x001F0400]['value']
+        obis_points[0x00000006]['value'] = -obis_points[0x00330400]['value'] if obis_points[0x002a0400]['value'] > 0 else obis_points[0x00330400]['value']
+        obis_points[0x00000007]['value'] = -obis_points[0x00470400]['value'] if obis_points[0x003E0400]['value'] > 0 else obis_points[0x00470400]['value']
 
         for obis_values in obis_points.values():
             print(obis_values['name'] + ": " +


### PR DESCRIPTION
Extended with forward and reverse energy counters for L1, L2 and L3.
Changed values for L1, L2 en L3 currents. Calculating current by dividing power by voltage isn't acurate. I've used the actual values of the meter and only change the sign if the current flows back to the grid.