### PR TITLE
Update dbus-sma-smartmeter.py

### DIFF
--- a/dbus-sma-smartmeter.py
+++ b/dbus-sma-smartmeter.py
@@ -267,7 +267,7 @@ def main():
     DBusGMainLoop(set_as_default=True)
 
     pvac_output = DbusSMAEMService(
-        servicename='com.victronenergy.grid.smaem', deviceinstance=0)
+        servicename='com.victronenergy.grid.smaem', deviceinstance=41)
 
     mainloop = GLib.MainLoop()
     mainloop.run()


### PR DESCRIPTION
Um den SHM als Gridmeter einbinden zu können, darf die DeviceInstance nicht =0 sein, sonst kommen die Daten zwar grundsätzlich im GX Device an und speedwire_test.py zeigt sie auch, aber sie werden nicht zur "Konsole" durchgeleitet. Mit =41 funktioniert es bei mir, die Suche nach der Info hat mich einen Tag gekostet - vielleicht wäre es ganz gut, die Änderung gleich im Skript zu übernehmen. Ansonsten Danke für die Arbeit!