### PR TITLE
Update dbus-sma-smartmeter.py add Phase Shift

### DIFF
--- a/dbus-sma-smartmeter.py
+++ b/dbus-sma-smartmeter.py
@@ -25,6 +25,11 @@ import sys
 import os
 import threading
 
+# 0 = L1,L2,L3
+# 1 = L2,L3,L1
+# 2 = L3,L1,L2
+PHASE_SHIFT = 2
+
 MULTICAST_IP = "239.12.255.254"
 MULTICAST_PORT = 9522
 # set serial from used energiemeter if more then one in your network otherwise set to 0
@@ -230,6 +235,8 @@ class DbusSMAEMService(object):
                 self._obis_points[0x00000006]['value'] = -self._obis_points[0x00330400]['value'] if self._obis_points[0x002a0400]['value'] > 0 else self._obis_points[0x00330400]['value']
                 self._obis_points[0x00000007]['value'] = -self._obis_points[0x00470400]['value'] if self._obis_points[0x003E0400]['value'] > 0 else self._obis_points[0x00470400]['value']
 
+				self._apply_phase_shift_to_obis_values()
+				
                 if self._hardware[SMASusyID]['active'] == False:
                     swr = self._obis_points[0x90000000]['value']
                     sw = str((swr >> 24) & 0xFF)
@@ -255,7 +262,50 @@ class DbusSMAEMService(object):
             self._dbusservice['/Ac/Power'] = 0
 
         return True
+		
+    def _apply_phase_shift_to_obis_values(self):
+        if PHASE_SHIFT == 0:
+            return
 
+        phase_groups = [
+            {
+                'voltage': 0x00200400,
+                'power':   0x00000002,
+                'current': 0x00000005,
+                'efwd':    0x00150800,
+                'erev':    0x00160800,
+            },
+            {
+                'voltage': 0x00340400,
+                'power':   0x00000003,
+                'current': 0x00000006,
+                'efwd':    0x00290800,
+                'erev':    0x002A0800,
+            },
+            {
+                'voltage': 0x00480400,
+                'power':   0x00000004,
+                'current': 0x00000007,
+                'efwd':    0x003D0800,
+                'erev':    0x003E0800,
+            },
+        ]
+
+        original = []
+        for group in phase_groups:
+            original.append({
+                key: self._obis_points[obis]['value']
+                for key, obis in group.items()
+            })
+
+        shift = PHASE_SHIFT % 3
+
+        for target_idx, group in enumerate(phase_groups):
+            source_idx = (target_idx + shift) % 3
+
+            for key, obis in group.items():
+                self._obis_points[obis]['value'] = original[source_idx][key]
+				
     def _handlechangedvalue(self, path, value):
         logger.debug("someone else updated %s to %s" % (path, value))
         return True  # accept the change


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h2>Add configurable phase rotation for SMA SHM2.0 / Speedwire dbus bridge</h2><h3>Motivation</h3><p>In some Victron ESS installations the physical phase order of the inverter differs from the phase order reported by the SMA SHM2.0 / Energy Meter.</p><p>Example:</p><ul><li><p>Victron MultiPlus connected on L3</p></li><li><p>SMA meter reports standard order L1/L2/L3</p></li><li><p>Existing workaround required external Node-RED phase remapping</p></li></ul><p>This caused:</p><ul><li><p>incorrect phase attribution in ESS</p></li><li><p>misleading AC load visualization</p></li><li><p>unnecessary external processing</p></li></ul><h3>Changes</h3><p>Adds a simple configurable static phase rotation:</p><pre><code class="language-python">PHASE_SHIFT = 0
</code></pre><p>Supported modes:</p>
Value | Mapping
-- | --
0 | L1,L2,L3
1 | L2,L3,L1
2 | L3,L1,L2

<p>The phase shift is applied internally to calculated OBIS values before publishing to dbus.</p><p>Affected values:</p><ul><li><p>Voltage</p></li><li><p>Current</p></li><li><p>Power</p></li><li><p>Forward energy</p></li><li><p>Reverse energy</p></li></ul><h3>Important implementation detail</h3><p>The rotation is intentionally applied BEFORE writing to dbus.</p><p>This avoids:</p><ul><li><p>temporary inconsistent dbus states</p></li><li><p>transient wrong phase assignments</p></li><li><p>ESS/systemcalc glitches at high update rates (e.g. 200 ms Speedwire broadcast)</p></li></ul><h3>Use case</h3><p>For systems where:</p><ul><li><p>SMA phase order differs from Victron wiring</p></li><li><p>MultiPlus is installed on another phase</p></li><li><p>users previously used Node-RED phase remapping</p></li></ul><p>This allows clean native correction directly inside the dbus bridge.</p><h3>Example</h3><p>For:</p><pre><code class="language-text">Victron L1 = SMA L3
Victron L2 = SMA L1
Victron L3 = SMA L2
</code></pre><p>use:</p><pre><code class="language-python">PHASE_SHIFT = 2
</code></pre><h3>Result</h3><ul><li><p>cleaner ESS integration</p></li><li><p>correct per-phase visualization</p></li><li><p>reduced Node-RED complexity</p></li><li><p>more deterministic control behavior</p></li></ul></body></html><!--EndFragment-->
</body>
</html>